### PR TITLE
Fix crash on Search box enter

### DIFF
--- a/Brofiler/SearchBox.xaml.cs
+++ b/Brofiler/SearchBox.xaml.cs
@@ -64,7 +64,7 @@ namespace Profiler
 		{
 			if (e.Key == Key.Enter || e.SystemKey == Key.Enter)
 			{
-				TextEnter(FilterText.Text);
+				TextEnter?.Invoke(FilterText.Text);
 			}
 		}
 


### PR DESCRIPTION
Brofiler crashes when pressing Enter in one of the search boxes. Don't remember which.
