### PR TITLE
Fix underscore rendering

### DIFF
--- a/Brofiler/Frames/FrameInfo.xaml
+++ b/Brofiler/Frames/FrameInfo.xaml
@@ -12,6 +12,20 @@
         <ItemsPanelTemplate x:Key="CategoryListStyle">
             <StackPanel Height="Auto" Width="Auto" Orientation="Horizontal"/>
         </ItemsPanelTemplate>
+        <Style x:Key="LabelUnderscoreStyle" BasedOn="{StaticResource {x:Type Label}}" TargetType="Label">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Label">
+                        <Border>
+                            <ContentPresenter
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                RecognizesAccessKey="False" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <Style x:Key="ButtonFocusVisual">
             <Setter Property="Control.Template">
                 <Setter.Value>
@@ -125,8 +139,8 @@
                             </Label.Background>
                         </Label>
                         <Label x:Name="SelfText" Grid.Column="0" Content="{Binding SelfDuration, Mode=OneTime}" ContentStringFormat="{}{0:0.###}" Padding="0,0,4,0" HorizontalAlignment="Right" Foreground="White" FontSize="8pt" />
-                        <Label Grid.Column="1" Content="{Binding Name, Mode=OneTime}" Padding="4,0,0,0" />
-                        <Label Grid.Column="2" Content="{Binding Path, Mode=OneTime}" Padding="4,0,0,0" Foreground="Gray" ContentStringFormat="{}[{0}]" Visibility="{Binding IsChecked, ElementName=ShowPathButton, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        <Label Grid.Column="1" Content="{Binding Name, Mode=OneTime}" Padding="4,0,0,0" Style="{StaticResource LabelUnderscoreStyle}"/>
+                        <Label Grid.Column="2" Content="{Binding Path, Mode=OneTime}" Padding="4,0,0,0" Style="{StaticResource LabelUnderscoreStyle}" Foreground="Gray" ContentStringFormat="{}[{0}]" Visibility="{Binding IsChecked, ElementName=ShowPathButton, Converter={StaticResource BooleanToVisibilityConverter}}" />
                     </Grid>
                     <HierarchicalDataTemplate.Triggers>
                         <DataTrigger Binding="{Binding IsChecked, ElementName=ShowPercentButton}" Value="True">

--- a/Brofiler/ThreadView/ThreadView.xaml
+++ b/Brofiler/ThreadView/ThreadView.xaml
@@ -8,6 +8,23 @@
              xmlns:DX="clr-namespace:Profiler.DirectX"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" Height="Auto">
+
+    <UserControl.Resources>
+        <Style x:Key="LabelUnderscoreStyle" BasedOn="{StaticResource {x:Type Label}}" TargetType="Label">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Label">
+                    <Border>
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            RecognizesAccessKey="False" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        </Style>
+    </UserControl.Resources>
     <Grid Height="Auto" Name="panel">
         <Grid.RowDefinitions>
             <RowDefinition Height="280*" />


### PR DESCRIPTION
Underscores in FrameInfo pane and in the ThreadView Popup were rendered and interpreted as accelerator keys.
Fix is based on https://stackoverflow.com/questions/40733/disable-wpf-label-accelerator-key-text-underscore-is-missing/40784#40784
Not sure if I caught all occurrences of this yet.