### PR TITLE
Fixed not focusing Tab if tab already exists

### DIFF
--- a/Brofiler/MainWindow.xaml.cs
+++ b/Brofiler/MainWindow.xaml.cs
@@ -80,6 +80,7 @@ namespace Profiler
                 if (tab is TabItem)
                 {
                     TabItem item = (TabItem)tab;
+                    frameTabs.SelectedItem = item;
                     if (item.DataContext.Equals(frame))
                     {
                         FrameInfo frameInfo = item.Content as FrameInfo;


### PR DESCRIPTION
When selecting a Thread in the TimeLine it should open the tab if it doesn't exist and focus it. If the tab is already open though it doesn't focus and instead stays on the previously active tab. This fixes that.

This fix looks kinda dirty to me. Just putting that inside the loop there. Do you have a better idea how to solve this?