### PR TITLE
Highlight frames that contain runtime of filtered function

### DIFF
--- a/Brofiler/Frames/FrameInfo.xaml.cs
+++ b/Brofiler/Frames/FrameInfo.xaml.cs
@@ -115,7 +115,10 @@ namespace Profiler
 						} else
 						{
 							double timeInMs = eventFrame.CalculateFilteredTime(filter);
-							eventFrame.FilteredDescription = String.Format("{0:0.000}", timeInMs);
+							if (timeInMs > 0)
+								eventFrame.FilteredDescription = String.Format("{0:0.000}", timeInMs);
+							else
+								eventFrame.FilteredDescription = "";
 						}
 					}
 				}


### PR DESCRIPTION
If you use the bottom right filter box to filter out a function the TimeLine displays the runtime spent in the filtered functions in that frame. 
But it's really hard to use for finding frames where the function get's called because frames that don't use it at all show 0,000 and finding the one 0,060 in there is quite hard on hundreds of frames.

Here is a screenshot of how it looks in my Fork. I changed the background color to Lime and Foreground to Black to make it even more visible.
This PR just removes 0,00 numbers from the display.
![brofiler_2018-03-28_16-25-03](https://user-images.githubusercontent.com/3768165/38078155-a7e76116-333b-11e8-902f-9b989f966eca.png)
