### PR TITLE
Fix fail to select ThreadView node

### DIFF
--- a/Brofiler/Frames/FrameInfo.xaml.cs
+++ b/Brofiler/Frames/FrameInfo.xaml.cs
@@ -236,6 +236,8 @@ namespace Profiler
 					finalNode.IsExpanded = false;
 					finalNode.IsSelected = true;
 
+					SelectedTreeNodeChanged(DataContext as Data.Frame, finalNode);
+
 					// focus on finalNode
 					if (root != null)
 					{


### PR DESCRIPTION
Sometimes when trying to select a node in the ThreadView it selects the full Frame instead of the node under the cursor.
I was able to 100% reproduce it by selecting a different frame. And then trying to select a node in the frame I want.

Tested for half an hour now with this fix and didn't experience the issue again. 

Without #34 behavior is slightly different. If you have a node or the full frame of frame 2 selected. Then you cannot select frame 1 but you can select nodes of frame 1.
Seems like a weird bug. But this fix fixes both weirdnesses.
Without #34 it doesn't switch the tab. It selects the correct item in ThreadView but the bottom left FrameInfo view is bugged. Which is exactly what #34 fixes
